### PR TITLE
Add tile sort button

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
 
     <div class="above-game">
       <p class="game-intro">Join the numbers and get to the <strong>2048 tile!</strong></p>
+      <a class="sort-button">Sort Tiles</a>
       <a class="restart-button">New Game</a>
     </div>
 

--- a/js/game_manager.js
+++ b/js/game_manager.js
@@ -9,6 +9,7 @@ function GameManager(size, InputManager, Actuator, StorageManager) {
   this.inputManager.on("move", this.move.bind(this));
   this.inputManager.on("restart", this.restart.bind(this));
   this.inputManager.on("keepPlaying", this.keepPlaying.bind(this));
+  this.inputManager.on("sort", this.sort.bind(this));
 
   this.setup();
 }
@@ -269,4 +270,42 @@ GameManager.prototype.tileMatchesAvailable = function () {
 
 GameManager.prototype.positionsEqual = function (first, second) {
   return first.x === second.x && first.y === second.y;
+};
+
+// Sort tiles so the largest value ends up in the bottom-right corner
+// and values decrease from right to left and bottom to top
+GameManager.prototype.sort = function () {
+  var self = this;
+
+  if (this.isGameTerminated()) return;
+
+  this.prepareTiles();
+
+  var tiles = [];
+
+  this.grid.eachCell(function (x, y, tile) {
+    if (tile) {
+      tiles.push(tile);
+      self.grid.removeTile(tile);
+    }
+  });
+
+  // Sort by value descending so highest values are placed first
+  tiles.sort(function (a, b) {
+    return b.value - a.value;
+  });
+
+  var index = 0;
+  for (var y = self.size - 1; y >= 0; y--) {
+    for (var x = self.size - 1; x >= 0; x--) {
+      if (index < tiles.length) {
+        var tile = tiles[index];
+        tile.updatePosition({ x: x, y: y });
+        self.grid.insertTile(tile);
+        index++;
+      }
+    }
+  }
+
+  this.actuate();
 };

--- a/js/keyboard_input_manager.js
+++ b/js/keyboard_input_manager.js
@@ -72,6 +72,7 @@ KeyboardInputManager.prototype.listen = function () {
   this.bindButtonPress(".retry-button", this.restart);
   this.bindButtonPress(".restart-button", this.restart);
   this.bindButtonPress(".keep-playing-button", this.keepPlaying);
+  this.bindButtonPress(".sort-button", this.sort);
 
   // Respond to swipe events
   var touchStartClientX, touchStartClientY;
@@ -135,6 +136,11 @@ KeyboardInputManager.prototype.restart = function (event) {
 KeyboardInputManager.prototype.keepPlaying = function (event) {
   event.preventDefault();
   this.emit("keepPlaying");
+};
+
+KeyboardInputManager.prototype.sort = function (event) {
+  event.preventDefault();
+  this.emit("sort");
 };
 
 KeyboardInputManager.prototype.bindButtonPress = function (selector, fn) {

--- a/style/main.css
+++ b/style/main.css
@@ -529,6 +529,20 @@ hr {
   display: block;
   text-align: center;
   float: right; }
+.sort-button {
+  display: inline-block;
+  background: #5c90e5;
+  border-radius: 3px;
+  padding: 0 20px;
+  text-decoration: none;
+  color: #f9f6f2;
+  height: 40px;
+  line-height: 42px;
+  display: block;
+  text-align: center;
+  float: right;
+  margin-right: 10px;
+}
 
 .game-explanation {
   margin-top: 50px; }
@@ -569,6 +583,13 @@ hr {
     display: block;
     box-sizing: border-box;
     margin-top: 2px; }
+  .sort-button {
+    width: 42%;
+    padding: 0;
+    display: block;
+    box-sizing: border-box;
+    margin-top: 2px;
+  }
 
   .game-container {
     margin-top: 17px;


### PR DESCRIPTION
## Summary
- add a sort button to the UI
- implement sort event in keyboard input manager
- wire sort handler in game manager
- provide a sort method that reorders tiles by value
- style the new sort button
- adjust sorting so largest tile lands in the bottom-right corner

## Testing
- `rake -T`


------
https://chatgpt.com/codex/tasks/task_e_688608a6b6888326b0752ecd9b22486a